### PR TITLE
Printout the whole stacktrace for CI jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ TruncatedStacktraces.@truncate_stacktrace ODEProblem 3 1 2
 For any new error exception you add to your package, make sure to include the note from TruncatedStacktraces.jl on
 how to effect the type printing. This is done by adding `println(io, VERBOSE_MSG)` to the bottom of any error message.
 
+## Default values
+
+`TruncatedStacktraces.VERBOSE[]` defaults to `false` for non-CI workflows and to `true` for CI jobs.
+
 ## FAQ: Why is this not in Base Julia?
 
 There are attempts like https://github.com/JuliaLang/julia/pull/48444, but no one agrees on what exactly to do and how to

--- a/src/TruncatedStacktraces.jl
+++ b/src/TruncatedStacktraces.jl
@@ -1,7 +1,7 @@
 module TruncatedStacktraces
 
 using InteractiveUtils, MacroTools
-const VERBOSE = Ref(false)
+const VERBOSE = Ref(parse(Bool, get(ENV, "CI", "false")))
 
 VERBOSE_MSG = """
 


### PR DESCRIPTION
- It would be useful to have the whole stack trace of failed CI jobs
- GitHub Actions ([see](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)) and Buildkite ([see](https://buildkite.com/docs/pipelines/environment-variables#CI)) set `CI = true`. Use the `ENV["CI"]` to set default `VERBOSE`
