### PR TITLE
Set to disabled as default (ie opt-in to TruncatedStacktraces, instead of opt-out)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Test"]
+test = ["Test", "UUIDs"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,35 @@ Don't you wish Julia stacktraces were simpler? Introducing TruncatedStacktraces.
 package is to give package authors a single uniform system for implementing truncation of type printing
 in stack traces.
 
+## Enabling TruncatedStacktraces.jl
+
+TruncatedStacktraces.jl is currently disabled by default, as it causes invalidations which will slow down package loading.
+
+It can be enabled using Preferences.jl. To enable it, create a `LocalPreferences.toml` with the following entry:
+
+```toml
+[TruncatedStacktraces]
+disable = false
+```
+
+Alternatively, you can generate the `LocalPreferences.toml` using:
+
+```julia
+using Preferences, UUIDs
+
+using TruncatedStacktraces
+Preferences.set_preferences!(TruncatedStacktraces, "disable" => false)
+
+# OR if you don't want to load TruncatedStacktraces.jl
+
+Preferences.set_preferences!(UUID("781d530d-4396-4725-bb49-402e4bee1e77"), "disable" => false)
+```
+
+In either case, you need to reload your packages (depending on TruncatedStacktraces) for the
+change to take effect.
+
+**TruncatedStacktraces is known to create invalidations, to remove these simply set the preference to disable it!**
+
 ## Users: How to Interact with TruncatedStacktraces.jl
 
 If a package you are using is making use of TruncatedStacktraces.jl, you will see shorter stack traces. Everything
@@ -52,35 +81,8 @@ how to effect the type printing. This is done by adding `println(io, VERBOSE_MSG
 ## Default values
 
     * `TruncatedStacktraces.VERBOSE[]` defaults to `false` for non-CI workflows and to `true` for CI jobs.
-    * `TruncatedStacktraces.DISABLE` defaults to `false`.
+    * `TruncatedStacktraces.DISABLE` defaults to `true`.
 
-## Disabling TruncatedStacktraces.jl
-
-TruncatedStacktraces.jl can be disabled using Preferences.jl. To disable it, create a
-`LocalPreferences.toml` with the following entry:
-
-```toml
-[TruncatedStacktraces]
-disable = true
-```
-
-Alternatively, you can generate the `LocalPreferences.toml` using:
-
-```julia
-using Preferences, UUIDs
-
-using TruncatedStacktraces
-Preferences.set_preferences!(TruncatedStacktraces, "disable" => true)
-
-# OR if you don't want to load TruncatedStacktraces.jl
-
-Preferences.set_preferences!(UUID("781d530d-4396-4725-bb49-402e4bee1e77"), "disable" => true)
-```
-
-In either case, you need to reload your packages (depending on TruncatedStacktraces) for the
-change to take effect.
-
-**TruncatedStacktraces is known to create invalidations, to remove these simply set the preference to disable it!**
 
 ## How It's Implemented
 

--- a/src/TruncatedStacktraces.jl
+++ b/src/TruncatedStacktraces.jl
@@ -3,7 +3,7 @@ module TruncatedStacktraces
 using InteractiveUtils, MacroTools, Preferences
 
 const VERBOSE = Ref(parse(Bool, get(ENV, "CI", "false")))
-const DISABLE = @load_preference("disable", false)
+const DISABLE = @load_preference("disable", true) # opt-in
 
 VERBOSE_MSG = """
 

--- a/src/TruncatedStacktraces.jl
+++ b/src/TruncatedStacktraces.jl
@@ -2,8 +2,9 @@ module TruncatedStacktraces
 
 using InteractiveUtils, MacroTools, Preferences
 
-const VERBOSE = Ref(parse(Bool, get(ENV, "CI", "false")))
-const DISABLE = @load_preference("disable", true) # opt-in
+
+const DISABLE = @load_preference("disable", true)
+const VERBOSE = Ref(parse(Bool, get(ENV, "CI", string(DISABLE))))
 
 VERBOSE_MSG = """
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,8 @@
+
+# default is disable = true, so explicitly enable first
+using Preferences, UUIDs
+Preferences.set_preferences!(UUID("781d530d-4396-4725-bb49-402e4bee1e77"), "disable" => false)
+
 using Test, TruncatedStacktraces
 
 @testset "Test that VERBOSE can remove the notice message" begin


### PR DESCRIPTION
Change default setting of `disabled` option to `true`, so package is disabled by default and requires a setting in `LocalPreferences.toml` to enable.

See https://github.com/SciML/TruncatedStacktraces.jl/issues/22, https://github.com/SciML/TruncatedStacktraces.jl/issues/23 enabling TruncatedStacktraces can cause significant slowdowns (minutes) in startup, and the LocalPreferences.toml mechanism to disable is not as straightforward as just adding the setting.